### PR TITLE
Fix changelog popping up randomly

### DIFF
--- a/Chrome/background.js
+++ b/Chrome/background.js
@@ -2,7 +2,8 @@ function handleInstalled(reason) {
 	browser.storage.sync.get(['reduxSettings'], function(result) {
 		if (Object.keys(result).length > 0 && !result.reduxSettings.showChangelog) {
 			return;
-		} else {
+		} 
+		else if (reason != "browser_update") {
 			chrome.tabs.create({
 				url: `./changelog.html#${reason}`
 			});

--- a/Firefox/background.js
+++ b/Firefox/background.js
@@ -2,8 +2,9 @@ function handleInstalled(reason) {
 	browser.storage.sync.get(['reduxSettings'], function(result) {
 		if (Object.keys(result).length > 0 && !result.reduxSettings.showChangelog) {
 			return;
-		} else {
-			chrome.tabs.create({
+		} 
+		else if (reason != "browser_update") {
+			browser.tabs.create({
 				url: `./changelog.html#${reason}`
 			});
 		}

--- a/Firefox/changelog.js
+++ b/Firefox/changelog.js
@@ -1,7 +1,7 @@
 function handleChangelog() {
 	let changelogHeader = document.querySelector('#youtube-redux-header');
 	let changelogVersion = document.querySelector('#version');
-	let version = chrome.runtime.getManifest().version;
+	let version = console.log(browser.runtime.getManifest().version);
 	if (!changelogHeader) return;
 	if (window.location.href.includes('#install')) {
 		changelogHeader.innerText = 'YouTube Redux has been installed!';

--- a/Firefox/changelog.js
+++ b/Firefox/changelog.js
@@ -1,7 +1,7 @@
 function handleChangelog() {
 	let changelogHeader = document.querySelector('#youtube-redux-header');
 	let changelogVersion = document.querySelector('#version');
-	let version = console.log(browser.runtime.getManifest().version);
+	let version = browser.runtime.getManifest().version;
 	if (!changelogHeader) return;
 	if (window.location.href.includes('#install')) {
 		changelogHeader.innerText = 'YouTube Redux has been installed!';


### PR DESCRIPTION
I noticed that Youtube Redux's changelog would appear randomly, even when there was no update. This was due to background.js's listener opening up the changelog even if only the _web browser_ updated. This fixes that, and also makes some calls in the Firefox repo be more browser-neutral (shouldn't have any effect on use).