### PR TITLE
Fixed related videos margin in theater mode

### DIFF
--- a/Chrome/styles.css
+++ b/Chrome/styles.css
@@ -225,6 +225,9 @@ ytd-watch-flexy:not([theater]):not([fullscreen]) #primary.ytd-watch-flexy,
 ytd-watch-flexy:not([theater]):not([fullscreen]) #secondary.ytd-watch-flexy {
     padding-top: 10px !important;
 }
+ytd-watch-flexy[theater] #secondary.ytd-watch-flexy {
+    margin-top: 12px !important;
+}
 ytd-expander.ytd-video-secondary-info-renderer {
     line-height:15px !important;
     font-size:13px !important;

--- a/Firefox/styles.css
+++ b/Firefox/styles.css
@@ -225,6 +225,9 @@ ytd-watch-flexy:not([theater]):not([fullscreen]) #primary.ytd-watch-flexy,
 ytd-watch-flexy:not([theater]):not([fullscreen]) #secondary.ytd-watch-flexy {
     padding-top: 10px !important;
 }
+ytd-watch-flexy[theater] #secondary.ytd-watch-flexy {
+    margin-top: 12px !important;
+}
 ytd-expander.ytd-video-secondary-info-renderer {
     line-height:15px !important;
     font-size:13px !important;


### PR DESCRIPTION
Fixed the spacing between the related videos column and the video player in theater mode to align with the title block. 

Before:
![image](https://user-images.githubusercontent.com/33195187/216205120-941e1ca2-68f6-4d20-a574-297c0bbbbfd0.png)
After:
![image](https://user-images.githubusercontent.com/33195187/216205152-4a7fb949-2242-482a-a168-5856ddbcd759.png)
